### PR TITLE
Add support for Windows

### DIFF
--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -167,6 +167,14 @@ class Supervisor
 
     private function isRunningPid(int $pid): bool
     {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $process = new Process(['tasklist', '/FI', "PID eq $pid"]);
+            $process->run();
+            
+            // Symfony Process starts Windows processes via cmd.exe
+            return str_contains($process->getOutput(), 'cmd.exe');
+        }
+
         $process = new Process(['ps', '-p', $pid]);
         $exitCode = $process->run();
 


### PR DESCRIPTION
This PR adds support for Windows by using `tasklist /FI "PID eq …"`. Since this executable will always exit with code `0` we instead have to inspect its output. Symfony Process will start any processes under Windows as a `cmd.exe` subprocess. As such `tasklist /FI "PID eq …"` will then have an output like this for the given process ID (with an English locale):

```
Image Name                     PID Session Name        Session#    Mem Usage
========================= ======== ================ =========== ============
cmd.exe                      15048 Console                    5      5
```

In case the PID is not found, the output will look like this:

```
INFO: No tasks are running which match the specified criteria.
```

Thus this PR assumes that as long as `cmd.exe` is in the output, the process with the given process ID is still actually running.