### PR TITLE
Use `posix_getpgid`

### DIFF
--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -182,6 +182,11 @@ class Supervisor
                 return str_contains($process->getOutput(), 'cmd.exe');
             }
 
+            // posix_getpgid returns false, if the process is not running anymore (see #2)
+            if (function_exists('posix_getpgid')) {
+                return false !== posix_getpgid($pid);
+            }
+
             $process = new Process(['ps', '-p', $pid]);
             $process->mustRun();
 

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -182,7 +182,7 @@ class Supervisor
                 return str_contains($process->getOutput(), 'cmd.exe');
             }
 
-            // posix_getpgid returns false, if the process is not running anymore (see #2)
+            // posix_getpgid returns false, if the process is not running anymore (see #3)
             if (function_exists('posix_getpgid')) {
                 return false !== posix_getpgid($pid);
             }


### PR DESCRIPTION
On some hosting environments `/proc` is not mounted and thus `ps -p` will not work. `posix_getpgid` should work in such instances. It will return `false` on failure, i.e. if the process does not exist.

However, it would also return `false` on _other_ failures of course, which we cannot detect.