### PR TITLE
Improve performance of `WindowsTaskListProvider::isSupported()`

### DIFF
--- a/src/Provider/WindowsTaskListProvider.php
+++ b/src/Provider/WindowsTaskListProvider.php
@@ -15,7 +15,7 @@ class WindowsTaskListProvider implements ProviderInterface
         }
 
         try {
-            $process = new Process(['tasklist']);
+            $process = new Process(['tasklist', '/FI', 'PID eq 0']);
             $process->mustRun();
 
             return true;


### PR DESCRIPTION
This PR adds a filter (`PID eq 0`) to the tasklist command in `WindowsTaskListProvider::isSupported()` to improve performance as mentioned in https://github.com/contao/contao/pull/9445.
While measuring the execution time of the tasklist command directly via PowerShell (`Measure-Command { tasklist | Out-Default }`) this seems to reduce execution time by about 85% in my case.

Note: I have only tested this directly with the tasklist command in PowerShell, as I usually don't use Windows and don't have a Windows machine with PHP and everything set up. 😅 