### PR TITLE
Optimize supervisor shutdown by waiting on tracked child processes

### DIFF
--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -172,26 +172,19 @@ class Supervisor
         // Okay, we are done supervising. Now we might have child processes that are
         // still running. We have to wait for them to finish. Only then we can exit
         // ourselves otherwise we'd kill the children
-        while ($this->hasRunningChildProcesses()) {
-            sleep($this->tickFrequency);
-        }
+        $this->waitForRunningChildProcesses();
     }
 
-    private function hasRunningChildProcesses(): bool
+    private function waitForRunningChildProcesses(): void
     {
-        $hasRunning = false;
-
         foreach ($this->childProcesses as $pid => $process) {
             if ($process->isRunning()) {
-                $hasRunning = true;
-                continue;
+                $process->wait();
             }
 
             unset($this->childProcesses[$pid]);
             $this->dispatch(self::EVENT_PROCESS_FINISHED, $pid);
         }
-
-        return $hasRunning;
     }
 
     private function doSupervise(): void

--- a/var/runner.php
+++ b/var/runner.php
@@ -16,13 +16,13 @@ if (!is_a($providerClass, ProviderInterface::class, true)) {
 
 (Supervisor::withProviders(__DIR__ . '/storage', [new $providerClass()]))
     ->withCommand(new BasicCommand('sleep 10', 2, function () {
-        return new Process(['sleep', '10']);
+        return new Process(['sleep', '10'], timeout: null);
     }))
     ->withCommand(new BasicCommand('sleep 20', 2, function() {
-        return new Process(['sleep', '20']);
+        return new Process(['sleep', '20'], timeout: null);
     }))
     ->withCommand(new BasicCommand('sleep 100', 2, function() {
-        return new Process(['sleep', '100']);  // Mock a process that will take longer than the 55 seconds of the supervisor itself
+        return new Process(['sleep', '100'], timeout: null);  // Mock a process that will take longer than the 55 seconds of the supervisor itself
     }))
     ->supervise(function(int $tick) {
         echo 'Tick: ' . $tick;


### PR DESCRIPTION
This changes the supervisor shutdown path to exit as soon as the child processes started by the current supervisor instance have actually finished, instead of waiting for the next 10-second tick.

/cc @fritzmg 