### PR TITLE
Use high-precision bounded sleep in supervise loop

### DIFF
--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -161,7 +161,11 @@ class Supervisor
             $this->doSupervise();
 
             // we check every $tickFrequency seconds whether we need to restart processes
-            usleep((int) max(0, min($frequency, ($end - microtime(true)) * 1000 * 1000)));
+            if (($delta = $end - microtime(true)) < 0) {
+                break;
+            }
+
+            usleep((int) min($frequency, $delta * 1000 * 1000));
 
             if (null !== $onTick) {
                 $onTick($tick);

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -157,11 +157,11 @@ class Supervisor
         $frequency = $this->tickFrequency * 1000 * 1000;
 
         // Supervise for as long as we did not hit $end
-        while (microtime(true) <= $end) {
+        while (microtime(true) < $end) {
             $this->doSupervise();
 
             // we check every $tickFrequency seconds whether we need to restart processes
-            if (($delta = $end - microtime(true)) <= 0) {
+            if (($delta = $end - microtime(true)) < 0) {
                 break;
             }
 

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -152,15 +152,16 @@ class Supervisor
             throw new \LogicException('No provider supported, cannot supervise!');
         }
 
-        $end = time() + 55;
+        $end = microtime(true) + 55;
         $tick = 1;
+        $frequency = $this->tickFrequency * 1000 * 1000;
 
         // Supervise for as long as we did not hit $end
-        while (time() <= $end) {
+        while (microtime(true) <= $end) {
             $this->doSupervise();
 
             // we check every $tickFrequency seconds whether we need to restart processes
-            sleep($this->tickFrequency);
+            usleep((int) max(0, min($frequency, ($end - microtime(true)) * 1000 * 1000)));
 
             if (null !== $onTick) {
                 $onTick($tick);

--- a/src/Supervisor.php
+++ b/src/Supervisor.php
@@ -161,11 +161,16 @@ class Supervisor
             $this->doSupervise();
 
             // we check every $tickFrequency seconds whether we need to restart processes
-            if (($delta = $end - microtime(true)) < 0) {
+            if (($delta = $end - microtime(true)) <= 0) {
                 break;
             }
 
-            usleep((int) min($frequency, $delta * 1000 * 1000));
+            $sleep = (int) min($frequency, $delta * 1000 * 1000);
+            if ($sleep <= 0) {
+                break;
+            }
+
+            usleep($sleep);
 
             if (null !== $onTick) {
                 $onTick($tick);


### PR DESCRIPTION
Switch supervise-loop timing to high-precision `microtime(true)` and replace fixed `sleep()` with bounded `usleep()` so the loop doesn’t overshoot its configured execution window by up to a full tick. Regular tick cadence and cleanup behavior stay unchanged.